### PR TITLE
enh: Provide `@nextcloud/typings/ocs` for `OCSResult` type

### DIFF
--- a/lib/ocs.ts
+++ b/lib/ocs.ts
@@ -1,0 +1,30 @@
+export interface OCSResponse<T = any> {
+	ocs: {
+		meta: {
+			/**
+			 * Request success or failure state
+			 */
+			status: 'ok' | 'failure'
+
+			/**
+			 * Status code defaults to 100, but often HTTP status codes are used
+			 */
+			statuscode: number
+
+			/**
+			 * Message text
+			 */
+			message: string | undefined
+
+			/**
+			 * Optionally the total number of items available
+			 */
+			totalitems: number | undefined
+			/**
+			 * Optionally the the number of items per page
+			 */
+			itemsperpage: number | undefined
+		}
+		data: T
+	}
+}

--- a/lib/v27/OC.d.ts
+++ b/lib/v27/OC.d.ts
@@ -1,4 +1,4 @@
-import { Route } from "vue-router";
+import type { Route } from 'vue-router'
 
 declare global {
     namespace Nextcloud.v27 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/jquery": "3.5.16",
-        "vue": "^2.7.14",
+        "vue": "^2.7.15",
         "vue-router": "<4"
       },
       "devDependencies": {
         "babel-jest": "^29.5.0",
         "jest": "^29.5.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.3.2"
       },
       "engines": {
         "node": "^20.0.0",
@@ -1217,9 +1217,9 @@
       "dev": true
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
+      "integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
       "dependencies": {
         "@babel/parser": "^7.18.4",
         "postcss": "^8.4.14",
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -3551,11 +3551,11 @@
       }
     },
     "node_modules/vue": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
+      "integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
       "dependencies": {
-        "@vue/compiler-sfc": "2.7.14",
+        "@vue/compiler-sfc": "2.7.15",
         "csstype": "^3.1.0"
       }
     },
@@ -4636,9 +4636,9 @@
       "dev": true
     },
     "@vue/compiler-sfc": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.14.tgz",
-      "integrity": "sha512-aNmNHyLPsw+sVvlQFQ2/8sjNuLtK54TC6cuKnVzAY93ks4ZBrvwQSnkkIh7bsbNhum5hJBS00wSDipQ937f5DA==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
+      "integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
       "requires": {
         "@babel/parser": "^7.18.4",
         "postcss": "^8.4.14",
@@ -5921,9 +5921,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -6356,11 +6356,11 @@
       }
     },
     "vue": {
-      "version": "2.7.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.14.tgz",
-      "integrity": "sha512-b2qkFyOM0kwqWFuQmgd4o+uHGU7T+2z3T+WQp8UBjADfEv2n4FEMffzBmCKNP0IGzOEEfYjvtcC62xaSKeQDrQ==",
+      "version": "2.7.15",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
+      "integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
       "requires": {
-        "@vue/compiler-sfc": "2.7.14",
+        "@vue/compiler-sfc": "2.7.15",
         "csstype": "^3.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Nextcloud TypeScript typings",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.d.ts",
+    "./types": "./dist/types.d.ts"
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest",
@@ -31,13 +35,13 @@
   },
   "dependencies": {
     "@types/jquery": "3.5.16",
-    "vue": "^2.7.14",
+    "vue": "^2.7.15",
     "vue-router": "<4"
   },
   "devDependencies": {
     "babel-jest": "^29.5.0",
     "jest": "^29.5.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.3.2"
   },
   "engines": {
     "node": "^20.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
-        "declaration": true,
-        "outDir": "./dist",
-        "strict": true,
-        "lib": [
-            "es6",
-            "dom"
-        ]
-    },
-    "include": [
-        "lib"
-    ],
-    "exclude": [
-        "dist",
-        "node_modules",
-        "test"
-    ]
+	"compilerOptions": {
+		"target": "ESNext",
+		"declaration": true,
+		"moduleResolution": "Node",
+		"outDir": "./dist",
+		"strict": true,
+		"lib": [
+			"ESNext",
+			"DOM"
+		]
+	},
+	"include": [
+		"lib"
+	],
+	"exclude": [
+		"dist",
+		"node_modules",
+		"test"
+	]
 }


### PR DESCRIPTION
I really often have to write the typing for it and so duplicate code, I think this should be part of the library.

But we could also discuss a different location.