### PR TITLE
fix: Do not depend on vue or vue-router for the public interface of `OC.Files.Router`

### DIFF
--- a/lib/v27/OC.d.ts
+++ b/lib/v27/OC.d.ts
@@ -1,46 +1,58 @@
-import type { Route } from 'vue-router'
+declare namespace Nextcloud.v27 {
+	type Dictionary<T> = { [index: string]: T }
 
-declare global {
-	namespace Nextcloud.v27 {
-		interface FilesRouter {
-			/**
-			* Trigger a route change on the files app
-			* 
-			* @param path the url path, eg: '/trashbin?dir=/Deleted'
-			* @param replace replace the current history (default false)
-			* @see https://router.vuejs.org/guide/essentials/navigation.html#navigate-to-a-different-location
-			*/
-			goTo(path: string, replace?: boolean): Promise<Route>;
-		
-			/**
-			 * Trigger a route change on the files App
-			 *
-			 * @param name the route name
-			 * @param params the route parameters
-			 * @param query the url query parameters
-			 * @param replace replace the current history
-			 * @see https://router.vuejs.org/guide/essentials/navigation.html#navigate-to-a-different-location
-			 */
-			goToRoute(
-				name?: string,
-				params?: Record<string, string>,
-				query?: Record<string, string | (string | null)[] | null | undefined>,
-				replace?: boolean,
-			): Promise<Route>;
+	interface Vue2RouteMeta extends Record<string | number | symbol, any> {}
+
+	interface Vue2Route {
+		path: string
+		name?: string | null
+		hash: string
+		query:	Dictionary<string | (string | null)[]>
+		params: Dictionary<string>
+		fullPath: string
+		matched: any[]
+		redirectedFrom?: string
+		meta?: Vue2RouteMeta
+	}
+
+	interface FilesRouter {
+		/**
+		* Trigger a route change on the files app
+		* 
+		* @param path the url path, eg: '/trashbin?dir=/Deleted'
+		* @param replace replace the current history (default false)
+		* @see https://v3.router.vuejs.org/guide/essentials/navigation.html
+		*/
+		goTo(path: string, replace?: boolean): Promise<Vue2Route>;
+	
+		/**
+		 * Trigger a route change on the files App
+		 *
+		 * @param name the route name
+		 * @param params the route parameters
+		 * @param query the url query parameters
+		 * @param replace replace the current history
+		 * @see https://v3.router.vuejs.org/guide/essentials/navigation.html
+		 */
+		goToRoute(
+			name?: string,
+			params?: Record<string, string>,
+			query?: Record<string, string | (string | null)[] | null | undefined>,
+			replace?: boolean,
+		): Promise<Vue2Route>;
+	}
+
+	interface OC extends Nextcloud.v26.OC {
+
+	}
+
+	interface OCP extends Omit<Nextcloud.v26.OCP, 'Files'> {
+		Files: {
+			Router: FilesRouter
 		}
+	}
 
-		interface OC extends Nextcloud.v26.OC {
+	interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
 
-		}
-
-		interface OCP extends Omit<Nextcloud.v26.OCP, 'Files'> {
-			Files: {
-				Router: FilesRouter
-			}
-		}
-
-		interface WindowWithGlobals extends Nextcloud.Common.DayMonthConstants, Window {
-
-		}
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.8.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@types/jquery": "3.5.16",
-        "vue": "^2.7.15",
-        "vue-router": "<4"
+        "@types/jquery": "3.5.16"
       },
       "devDependencies": {
         "babel-jest": "^29.5.0",
@@ -455,6 +453,7 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
       "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1216,16 +1215,6 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "2.7.15",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
-      "integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
-      "dependencies": {
-        "@babel/parser": "^7.18.4",
-        "postcss": "^8.4.14",
-        "source-map": "^0.6.1"
-      }
-    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -1606,11 +1595,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/debug": {
       "version": "4.1.1",
@@ -2904,23 +2888,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3071,11 +3038,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -3107,33 +3069,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pretty-format": {
@@ -3314,14 +3249,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3535,20 +3463,6 @@
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/vue": {
-      "version": "2.7.15",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
-      "integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
-      "dependencies": {
-        "@vue/compiler-sfc": "2.7.15",
-        "csstype": "^3.1.0"
-      }
-    },
-    "node_modules/vue-router": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
-      "integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
     },
     "node_modules/walker": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
     "url": "https://github.com/nextcloud/nextcloud-typings"
   },
   "dependencies": {
-    "@types/jquery": "3.5.16",
-    "vue": "^2.7.15",
-    "vue-router": "<4"
+    "@types/jquery": "3.5.16"
   },
   "devDependencies": {
     "babel-jest": "^29.5.0",


### PR DESCRIPTION
Having vue types is not a good idea, this will become a problem if you depend on multiple versions of vue-router.

<del>So for this functions are basically only provided for triggering route changes, so we can simply set them to `Promise` return type.</del>

So we should bundle the exact types used on that exact server version.