### PR TITLE
fix: Add missing `OC` constant types

### DIFF
--- a/lib/v16/OC.d.ts
+++ b/lib/v16/OC.d.ts
@@ -4,7 +4,17 @@
 declare namespace Nextcloud.v16 {
 
     interface OC extends Nextcloud.Common.OC {
+        coreApps: string[]
+        menuSpeed: number
+        TAG_FAVORITE: string
 
+        PERMISSION_NONE: 0
+        PERMISSION_READ: 1
+        PERMISSION_UPDATE: 2
+        PERMISSION_CREATE: 4
+        PERMISSION_DELETE: 8
+        PERMISSION_SHARE: 16
+        PERMISSION_ALL: 31
     }
 
     interface OCP extends Nextcloud.Common.OCP {


### PR DESCRIPTION
Missing type from OC constants