### PR TITLE
fix: Add missing types for confirmation dialogs

### DIFF
--- a/lib/common/OC.d.ts
+++ b/lib/common/OC.d.ts
@@ -19,6 +19,9 @@ declare namespace Nextcloud.Common {
         FILEPICKER_TYPE_COPY: number;
         FILEPICKER_TYPE_COPY_MOVE: number;
 
+        readonly YES_NO_BUTTONS: number,
+        readonly OK_BUTTONS: number,
+
         filepicker(
             title: string,
             callback: Function,
@@ -26,7 +29,38 @@ declare namespace Nextcloud.Common {
             mimeTypeFilter?: Array<string>,
             modal?: boolean,
             type?: number,
-            path?: string): void;
+            path?: string,
+        ): void;
+
+        /**
+         * Displays confirmation dialog
+         * @param text content of dialog
+         * @param title dialog title
+         * @param callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
+         * @param modal make the dialog modal
+         */
+        confirm(
+            text: string,
+            title: string,
+            callback: (answer: boolean) => void,
+            modal?: boolean,
+        ): Promise<void>;
+
+        /**
+         * Displays confirmation dialog
+         * @param text content of dialog
+         * @param title dialog title
+         * @param buttons text content of buttons
+         * @param callback which will be triggered when user presses OK (true or false would be passed to callback respectively)
+         * @param modal make the dialog modal
+         */
+        confirmDestructive(
+            text: string,
+            title: string,
+            buttons: number | { type: number, confirm: string, cancel: string, confirmClasses: string },
+            callback: (answer: boolean) => void,
+            modal?: boolean,
+        ): Promise<void>;
     }
 
     interface TranslationOptions {

--- a/lib/v17/OC.d.ts
+++ b/lib/v17/OC.d.ts
@@ -4,12 +4,8 @@ declare namespace Nextcloud.v17 {
         allowDirectoryChooser: boolean
     }
 
-    interface Dialogs {
-        FILEPICKER_TYPE_CHOOSE: number;
-        FILEPICKER_TYPE_MOVE: number;
-        FILEPICKER_TYPE_COPY: number;
-        FILEPICKER_TYPE_COPY_MOVE: number;
-
+    interface Dialogs extends Omit<Nextcloud.v16.OC['dialogs'], 'filepicker'>{
+        // options parameter was added
         filepicker(
             title: string,
             callback: Function,
@@ -18,7 +14,8 @@ declare namespace Nextcloud.v17 {
             modal?: boolean,
             type?: number,
             path?: string,
-            options?: FilePickerOptions): void;
+            options?: FilePickerOptions,
+        ): void;
     }
 
     interface OC extends Nextcloud.v16.OC {


### PR DESCRIPTION
The types are missing (even if deprecated now we still need them for some apps and even server core)