### PR TITLE
chore: Prepare v1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.9.1 - 2024-07-04
+### Fixed
+* fix: Add missing types for `OCP.Files.Router`
+* fix: Use Typescript source files for types
+* fix: Add missing types for confirmation dialogs
+
 ## 1.9.0 - 2024-06-25
 ### Added
 * feat: Add type information for Nextcloud 29

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/typings",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/typings",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@types/jquery": "3.5.16"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/typings",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Nextcloud TypeScript typings",
   "main": "dist/index.js",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
## 1.9.1 - 2024-07-04
### Fixed
* fix: Add missing types for `OCP.Files.Router`
* fix: Use Typescript source files for types
* fix: Add missing types for confirmation dialogs